### PR TITLE
feat!: make tool.when accept a context object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ async function getTools(
   // Filter extraTools based on templateName
   const filteredExtraTools = extraTools?.filter((tool) => {
     const when = tool.when ?? (() => true);
-    return templateName ? when(templateName) : true;
+    return templateName ? when({ templateName }) : true;
   });
 
   if (parsedTools !== null) {
@@ -367,7 +367,7 @@ type ExtraTool = {
    * If returns false, the tool will not be shown in the selection.
    * @default () => true
    */
-  when?: (templateName: string) => boolean;
+  when?: (context: { templateName: string }) => boolean;
 };
 
 type ExtraSkill = {

--- a/test/custom-tools.test.ts
+++ b/test/custom-tools.test.ts
@@ -237,7 +237,7 @@ test('should filter extra tools based on template name', async () => {
         value: 'filtered-tool',
         label: 'Filtered Tool',
         // This tool should be filtered out for 'vanilla' template
-        when: (templateName) => templateName !== 'vanilla',
+        when: ({ templateName }) => templateName !== 'vanilla',
         action: () => {
           filteredToolCalled = true;
         },
@@ -246,7 +246,7 @@ test('should filter extra tools based on template name', async () => {
         value: 'allowed-tool',
         label: 'Allowed Tool',
         // This tool should be allowed for 'vanilla' template
-        when: (templateName) => templateName === 'vanilla',
+        when: ({ templateName }) => templateName === 'vanilla',
         action: () => {
           allowedToolCalled = true;
         },


### PR DESCRIPTION
## Summary
- make `extraTools.when` accept a single context object instead of a positional `templateName` argument
- update tool filtering to call `when({ templateName })`
- align the custom tool tests with the new API shape

## Migration
Before:

```ts
when: (templateName) => templateName === 'react'
```

After:

```ts
when: ({ templateName }) => templateName === 'react'
```

## Testing
- `pnpm test`
