### PR TITLE
chore: simplify template package names

### DIFF
--- a/template-biome/package.json
+++ b/template-biome/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-biome",
+  "name": "biome",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/react-js/package.json
+++ b/template-eslint/react-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-react-js",
+  "name": "eslint-react-js",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/react-ts/package.json
+++ b/template-eslint/react-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-react-ts",
+  "name": "eslint-react-ts",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/svelte-js/package.json
+++ b/template-eslint/svelte-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-svelte-js",
+  "name": "eslint-svelte-js",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/svelte-ts/package.json
+++ b/template-eslint/svelte-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-svelte-ts",
+  "name": "eslint-svelte-ts",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/vanilla-js/package.json
+++ b/template-eslint/vanilla-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-common-js",
+  "name": "eslint-common-js",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/vanilla-ts/package.json
+++ b/template-eslint/vanilla-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-common-ts",
+  "name": "eslint-common-ts",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/vue-js/package.json
+++ b/template-eslint/vue-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-vue-js",
+  "name": "eslint-vue-js",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-eslint/vue-ts/package.json
+++ b/template-eslint/vue-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-eslint-vue-ts",
+  "name": "eslint-vue-ts",
   "private": true,
   "version": "1.0.0",
   "scripts": {

--- a/template-prettier/package.json
+++ b/template-prettier/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rsbuild-prettier",
+  "name": "prettier",
   "private": true,
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- replace the old `rsbuild-*` package names in the Biome, ESLint, and Prettier templates with shorter template package names
- keep the generated template manifests aligned with the selected tool and variant names

## Testing
- pnpm test

## Related Links
- None
