### PR TITLE
ci: run lint in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,13 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install && npx playwright install
+        run: pnpm install
+
+      - name: Run Lint
+        run: pnpm run lint
+
+      - name: Install Playwright
+        run: npx playwright install
 
       - name: Run Test
         run: pnpm run build && pnpm run test

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@ node_modules
 dist/
 test-results
 test-temp-*
+.rslib
 
 # IDE
 .vscode/*
 !.vscode/settings.json
 !.vscode/extensions.json
 .idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ test-temp-*
 !.vscode/settings.json
 !.vscode/extensions.json
 .idea
-


### PR DESCRIPTION
## Summary
- Run `pnpm run lint` in the existing test workflow so lint failures fail CI before Playwright setup and tests.
- Split dependency installation from Playwright installation to avoid unnecessary browser setup when lint already fails.

## Related Links
- None