### PR TITLE
fix(eslint): align language option defaults

### DIFF
--- a/template-eslint/react-js/eslint.config.mjs
+++ b/template-eslint/react-js/eslint.config.mjs
@@ -14,16 +14,10 @@ export default defineConfig([
       reactRefresh.configs.recommended,
     ],
     languageOptions: {
-      ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
-        ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },
-        sourceType: 'module',
       },
-    },
-    rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
 ]);

--- a/template-eslint/react-ts/eslint.config.mjs
+++ b/template-eslint/react-ts/eslint.config.mjs
@@ -16,7 +16,6 @@ export default defineConfig([
       reactRefresh.configs.recommended,
     ],
     languageOptions: {
-      ecmaVersion: 2020,
       globals: globals.browser,
     },
   },


### PR DESCRIPTION
## Summary
- Align the React ESLint templates with ESLint's recommended language option defaults by removing explicit `ecmaVersion` and `sourceType` settings that already default to `"latest"` and `"module"`.
- Drop the extra `no-unused-vars` override from the React JS template so the generated config stays closer to the baseline recommended config.

## Related Links
- https://eslint.org/docs/latest/use/configure/language-options