### PR TITLE
chore: fix mapRslintTemplate comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -339,6 +339,19 @@ export type RslintTemplateName =
   | 'react-js'
   | 'react-ts';
 
+const rslintTemplateNames = new Set<string>([
+  'vanilla-js',
+  'vanilla-ts',
+  'react-js',
+  'react-ts',
+]);
+
+function isRslintTemplateName(
+  templateName: ESLintTemplateName | null,
+): templateName is RslintTemplateName {
+  return templateName !== null && rslintTemplateNames.has(templateName);
+}
+
 const readJSON = async (path: string) =>
   JSON.parse(await fs.promises.readFile(path, 'utf-8'));
 
@@ -787,9 +800,18 @@ export async function create({
     }
 
     if (tool === 'rslint') {
-      const rslintTemplateName = mapRslintTemplate
-        ? mapRslintTemplate(templateName, { distFolder })
-        : 'vanilla-ts';
+      let rslintTemplateName: RslintTemplateName | null;
+
+      if (mapRslintTemplate) {
+        rslintTemplateName = mapRslintTemplate(templateName, { distFolder });
+      } else {
+        const eslintTemplateName = mapESLintTemplate
+          ? mapESLintTemplate(templateName, { distFolder })
+          : null;
+        rslintTemplateName = isRslintTemplateName(eslintTemplateName)
+          ? eslintTemplateName
+          : 'vanilla-ts';
+      }
 
       if (!rslintTemplateName) {
         continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,19 +339,6 @@ export type RslintTemplateName =
   | 'react-js'
   | 'react-ts';
 
-const rslintTemplateNames = new Set<string>([
-  'vanilla-js',
-  'vanilla-ts',
-  'react-js',
-  'react-ts',
-]);
-
-function isRslintTemplateName(
-  templateName: ESLintTemplateName | null,
-): templateName is RslintTemplateName {
-  return templateName !== null && rslintTemplateNames.has(templateName);
-}
-
 const readJSON = async (path: string) =>
   JSON.parse(await fs.promises.readFile(path, 'utf-8'));
 
@@ -800,18 +787,9 @@ export async function create({
     }
 
     if (tool === 'rslint') {
-      let rslintTemplateName: RslintTemplateName | null;
-
-      if (mapRslintTemplate) {
-        rslintTemplateName = mapRslintTemplate(templateName, { distFolder });
-      } else {
-        const eslintTemplateName = mapESLintTemplate
-          ? mapESLintTemplate(templateName, { distFolder })
-          : null;
-        rslintTemplateName = isRslintTemplateName(eslintTemplateName)
-          ? eslintTemplateName
-          : 'vanilla-ts';
-      }
+      const rslintTemplateName = mapRslintTemplate
+        ? mapRslintTemplate(templateName, { distFolder })
+        : 'vanilla-ts';
 
       if (!rslintTemplateName) {
         continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,7 +561,7 @@ export async function create({
   ) => ESLintTemplateName | null;
   /**
    * Map the template name to the Rslint template name.
-   * If not provided, reuses mapESLintTemplate and falls back to 'vanilla-ts'.
+   * If not provided, defaults to 'vanilla-ts' for all templates.
    */
   mapRslintTemplate?: (
     templateName: string,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -110,69 +110,6 @@ test('should scaffold mapped rslint tool template', async () => {
   expect(fs.existsSync(path.join(projectDir, 'react-ts'))).toBe(false);
 });
 
-test('should reuse eslint template mapping for rslint when rslint mapping is not provided', async () => {
-  const projectDir = path.join(testDir, 'rslint-tool-with-eslint-mapping');
-
-  await create({
-    name: 'test',
-    root: fixturesDir,
-    templates: ['vanilla'],
-    getTemplateName: async () => 'vanilla',
-    mapESLintTemplate: () => 'react-js',
-    argv: [
-      'node',
-      'test',
-      '--dir',
-      projectDir,
-      '--template',
-      'vanilla',
-      '--tools',
-      'rslint',
-    ],
-  });
-
-  const config = fs.readFileSync(
-    path.join(projectDir, 'rslint.config.ts'),
-    'utf-8',
-  );
-
-  expect(config).toContain('reactPlugin.configs.recommended');
-  expect(config).not.toContain('ts.configs.recommended');
-});
-
-test('should fallback to vanilla-ts when eslint mapping cannot be reused for rslint', async () => {
-  const projectDir = path.join(
-    testDir,
-    'rslint-tool-with-unsupported-eslint-mapping',
-  );
-
-  await create({
-    name: 'test',
-    root: fixturesDir,
-    templates: ['vanilla'],
-    getTemplateName: async () => 'vanilla',
-    mapESLintTemplate: () => 'vue-ts',
-    argv: [
-      'node',
-      'test',
-      '--dir',
-      projectDir,
-      '--template',
-      'vanilla',
-      '--tools',
-      'rslint',
-    ],
-  });
-
-  const config = fs.readFileSync(
-    path.join(projectDir, 'rslint.config.ts'),
-    'utf-8',
-  );
-
-  expect(config).toContain('ts.configs.recommended');
-  expect(config).not.toContain('reactPlugin.configs.recommended');
-});
-
 test('should skip tools selection', async () => {
   const projectDir = path.join(testDir, 'comma-separated-tools');
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -110,6 +110,69 @@ test('should scaffold mapped rslint tool template', async () => {
   expect(fs.existsSync(path.join(projectDir, 'react-ts'))).toBe(false);
 });
 
+test('should reuse eslint template mapping for rslint when rslint mapping is not provided', async () => {
+  const projectDir = path.join(testDir, 'rslint-tool-with-eslint-mapping');
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    mapESLintTemplate: () => 'react-js',
+    argv: [
+      'node',
+      'test',
+      '--dir',
+      projectDir,
+      '--template',
+      'vanilla',
+      '--tools',
+      'rslint',
+    ],
+  });
+
+  const config = fs.readFileSync(
+    path.join(projectDir, 'rslint.config.ts'),
+    'utf-8',
+  );
+
+  expect(config).toContain('reactPlugin.configs.recommended');
+  expect(config).not.toContain('ts.configs.recommended');
+});
+
+test('should fallback to vanilla-ts when eslint mapping cannot be reused for rslint', async () => {
+  const projectDir = path.join(
+    testDir,
+    'rslint-tool-with-unsupported-eslint-mapping',
+  );
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    mapESLintTemplate: () => 'vue-ts',
+    argv: [
+      'node',
+      'test',
+      '--dir',
+      projectDir,
+      '--template',
+      'vanilla',
+      '--tools',
+      'rslint',
+    ],
+  });
+
+  const config = fs.readFileSync(
+    path.join(projectDir, 'rslint.config.ts'),
+    'utf-8',
+  );
+
+  expect(config).toContain('ts.configs.recommended');
+  expect(config).not.toContain('reactPlugin.configs.recommended');
+});
+
 test('should skip tools selection', async () => {
   const projectDir = path.join(testDir, 'comma-separated-tools');
 


### PR DESCRIPTION
To be honest, I don’t think the original behavior is improper, but it does not match the comment.

`index.ts` currently says:

```ts
/**
 * Map the template name to the Rslint template name.
 * If not provided, reuses mapESLintTemplate and falls back to 'vanilla-ts'.
 */
mapRslintTemplate?: (
```

this pr reuses mapESLintTemplate first.