### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev": "rslib --watch",
     "lint": "rslint && prettier . --check",
     "lint:fix": "rslint --fix && prettier . --write",
-    "prepare": "simple-git-hooks && rslib",
+    "prepare": "simple-git-hooks",
     "test": "rstest",
     "bump": "npx bumpp"
   },


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove the duplicate build command from `scripts.prepare` now that release builds explicitly.

## Validation

- Verified staged publish workflows have a preceding `pnpm build`.
- Ran `git diff --check`.