### PR TITLE
chore: optimize CI pnpm setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.16.0
+          package-manager-cache: false
 
-      - name: Setup Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
-      - name: Install Dependencies
-        run: pnpm i
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: Build Packages
         run: pnpm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Pnpm
-        run: npm i -g corepack@latest --force && corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.16.0
-          cache: 'pnpm'
+          package-manager-cache: false
 
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: Run Lint
         run: pnpm run lint


### PR DESCRIPTION
## Summary

This PR aligns the GitHub Actions pnpm setup with the current Rsbuild workflow pattern from https://github.com/web-infra-dev/rsbuild/pull/7856.

- Replace corepack/manual pnpm install steps with `pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093` and `run_install: true`.
- Explicitly disable `actions/setup-node` package manager caching with `package-manager-cache: false`.
- Keep browser installation commands as separate post-install steps where needed.