### PR TITLE
chore: update pnpm release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,14 @@ allowBuilds:
   simple-git-hooks: false
 
 minimumReleaseAgeExclude:
-  - '@rspack/*'
   - '@rsbuild/*'
   - '@rslib/*'
-  - '@rstest/*'
   - '@rslint/*'
+  - '@rspack/*'
+  - '@rspress/*'
+  - '@rstackjs/*'
+  - '@rstest/*'
   - '@typescript/*'
+  - 'rsbuild-plugin-*'
+  - rstack
   - typescript


### PR DESCRIPTION
## Summary

This PR updates `minimumReleaseAgeExclude` to exempt Rstack ecosystem packages from pnpm's minimum release age policy. It preserves existing exclusions and sorts the complete list alphabetically.