### PR TITLE
chore(ci): remove unnecessary Playwright install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,5 @@ jobs:
       - name: Run Lint
         run: pnpm run lint
 
-      - name: Install Playwright
-        run: npx playwright install
-
       - name: Run Test
         run: pnpm run build && pnpm run test


### PR DESCRIPTION
This PR removes an unused Playwright browser installation step from CI because the workflow does not run browser-based tests. This avoids downloading browser binaries during every CI run.