### PR TITLE
chore: rename package to @rstackjs/create-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# create-rstack
+# @rstackjs/create-toolkit
 
 A shared package for create-rspack, create-rsbuild, create-rspress and create-rslib.
 
 > This package should only be used in Rstack projects.
 
+> [!NOTE]
+> This package was renamed from `create-rstack` to `@rstackjs/create-toolkit`.
+> Update your dependencies and imports to use the new package name.
+
 <p>
-  <a href="https://npmjs.com/package/create-rstack">
-   <img src="https://img.shields.io/npm/v/create-rstack?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" />
+  <a href="https://npmjs.com/package/@rstackjs/create-toolkit">
+   <img src="https://img.shields.io/npm/v/@rstackjs/create-toolkit?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" />
   </a>
   <img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" />
 </p>
@@ -14,14 +18,14 @@ A shared package for create-rspack, create-rsbuild, create-rspress and create-rs
 ## Install
 
 ```bash
-npm add create-rstack -D
+npm add @rstackjs/create-toolkit -D
 ```
 
 ## Features
 
 ### NPM Template Support
 
-`create-rstack` supports using npm packages as templates, allowing users to create projects from custom templates published to npm.
+`@rstackjs/create-toolkit` supports using npm packages as templates, allowing users to create projects from custom templates published to npm.
 
 #### Usage
 
@@ -67,7 +71,7 @@ import {
   isNpmTemplate,
   resolveCustomTemplate,
   resolveNpmTemplate,
-} from 'create-rstack';
+} from '@rstackjs/create-toolkit';
 
 // Check if template input is an npm package
 if (isNpmTemplate(templateInput)) {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "create-rstack",
+  "name": "@rstackjs/create-toolkit",
   "version": "2.1.3",
   "description": "Create a new Rstack project",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rstackjs/create-rstack"
+    "url": "https://github.com/rstackjs/create-toolkit"
   },
   "license": "MIT",
   "type": "module",

--- a/src/template-manager.ts
+++ b/src/template-manager.ts
@@ -98,7 +98,7 @@ export function resolveNpmTemplate(
   fs.mkdirSync(installRoot, { recursive: true });
   const anchorPkgJson = path.join(installRoot, 'package.json');
   if (!fs.existsSync(anchorPkgJson)) {
-    const minimal = { name: 'create-rstack-template-cache', private: true };
+    const minimal = { name: 'create-toolkit-template-cache', private: true };
     fs.writeFileSync(
       anchorPkgJson,
       `${JSON.stringify(minimal, null, 2)}\n`,
@@ -192,6 +192,6 @@ export function resolveCustomTemplate(
     return resolveNpmTemplate(trimmedInput, version, options);
   }
 
-  // For GitHub URLs or local paths, return as-is (handled by create-rstack)
+  // For GitHub URLs or local paths, return as-is (handled by create-toolkit)
   return trimmedInput;
 }


### PR DESCRIPTION
## Summary

The `create-rstack` package name is being reserved for project creation in Rstack CLI. This PR renames the shared package to `@rstackjs/create-toolkit`, updates the repository metadata and internal references, and documents the dependency and import migration in the README.

## Related Links

- https://github.com/rstackjs/rstack-cli