### PR TITLE
feat: support configuring built-in tools

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
   "search.useIgnoreFiles": true,
-  "cSpell.words": [
-    "rslint",
-    "rstackjs"
-  ]
+  "cSpell.words": ["rslint", "rstackjs"]
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ npm add @rstackjs/create-toolkit -D
 
 ## Features
 
+### Configure Built-in Tools
+
+The toolkit provides ESLint, Rslint, Biome, and Prettier as built-in tools. Use
+`builtinTools` to control which of them are available without affecting tools
+added through `extraTools`:
+
+```ts
+create({
+  // Disable all built-in tools.
+  builtinTools: [],
+  // Custom tools remain available.
+  extraTools: [{ value: 'custom-tool', label: 'Custom Tool' }],
+  // ...other options
+});
+```
+
+Omit the option to enable every built-in tool. Pass an array such as
+`['rslint', 'prettier']` to enable only those tools.
+
 ### NPM Template Support
 
 `@rstackjs/create-toolkit` supports using npm packages as templates, allowing users to create projects from custom templates published to npm.

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,15 +126,47 @@ export type Argv = {
   'template-version'?: string;
 };
 
-export const BUILTIN_TOOLS = ['eslint', 'rslint', 'biome', 'prettier'];
+export type BuiltinToolName = 'eslint' | 'rslint' | 'biome' | 'prettier';
+
+export const BUILTIN_TOOLS: BuiltinToolName[] = [
+  'eslint',
+  'rslint',
+  'biome',
+  'prettier',
+];
+
+type ToolOption = {
+  value: string;
+  label: string;
+  hint?: string;
+};
+
+const BUILTIN_TOOL_OPTIONS: Array<ToolOption & { value: BuiltinToolName }> = [
+  { value: 'rslint', label: 'Rslint - linting' },
+  { value: 'eslint', label: 'ESLint - linting' },
+  { value: 'prettier', label: 'Prettier - formatting' },
+  { value: 'biome', label: 'Biome - linting & formatting' },
+];
+
+function resolveBuiltinTools(
+  builtinTools: BuiltinToolName[] | undefined,
+): BuiltinToolName[] {
+  if (Array.isArray(builtinTools)) {
+    const selectedTools = new Set(builtinTools);
+    return BUILTIN_TOOLS.filter((tool) => selectedTools.has(tool));
+  }
+
+  return [...BUILTIN_TOOLS];
+}
 
 function logHelpMessage(
   name: string,
   templates: string[],
+  builtinTools: BuiltinToolName[] | undefined,
   extraTools?: ExtraTool[],
   extraSkills?: ExtraSkill[],
 ) {
-  const toolsList = [...BUILTIN_TOOLS];
+  const toolsList: string[] = resolveBuiltinTools(builtinTools);
   // Keep help output exhaustive for discoverability. `skill.when` only gates
   // the interactive prompt, not the documented list of available skills.
   const skillsList = (extraSkills ?? [])
@@ -154,8 +186,17 @@ function logHelpMessage(
     }
   }
 
+  const hasTools = toolsList.length > 0;
+  const toolsOptionLine = hasTools
+    ? '      --tools <tool>        add additional tools, comma separated\n'
+    : '';
   const skillsOptionLine = hasSkills
     ? '      --skill <skill>       add optional skills, comma separated\n'
+    : '';
+  const optionalToolsSection = hasTools
+    ? `
+    Optional tools:
+       ${toolsList.join(', ')}`
     : '';
   const optionalSkillsSection = hasSkills
     ? `
@@ -171,26 +212,25 @@ function logHelpMessage(
      -h, --help            display help for command
       -d, --dir <dir>       create project in specified directory
       -t, --template <tpl>  specify the template to use
-      --tools <tool>        add additional tools, comma separated
-${skillsOptionLine}      --override            override files in target directory
+${toolsOptionLine}${skillsOptionLine}      --override            override files in target directory
       --packageName <name>  specify the package name
       --template-version <ver>  specify the npm template version
     
     Available templates:
-      ${templates.join(', ')}
-
-    Optional tools:
-       ${toolsList.join(', ')}${optionalSkillsSection}
+      ${templates.join(', ')}${optionalToolsSection}${optionalSkillsSection}
 `);
 }
 
 async function getTools(
   { tools, dir, template }: Argv,
+  builtinTools: BuiltinToolName[] | undefined,
   extraTools?: ExtraTool[],
   templateName?: string,
 ) {
   // Check if tools are specified via CLI options
   const parsedTools = parseToolsOption(tools);
+  const enabledBuiltinTools = resolveBuiltinTools(builtinTools);
+  const enabledBuiltinToolSet = new Set<string>(enabledBuiltinTools);
 
   // Filter extraTools based on templateName
   const filteredExtraTools = extraTools?.filter((tool) => {
@@ -201,7 +241,7 @@ async function getTools(
   if (parsedTools !== null) {
     const toolsArr = parsedTools.filter(
       (tool) =>
-        BUILTIN_TOOLS.includes(tool) ||
+        enabledBuiltinToolSet.has(tool) ||
         filteredExtraTools?.some((extraTool) => extraTool.value === tool),
     );
     return toolsArr;
@@ -211,12 +251,9 @@ async function getTools(
     return [];
   }
 
-  const options = [
-    { value: 'rslint', label: 'Rslint - linting' },
-    { value: 'eslint', label: 'ESLint - linting' },
-    { value: 'prettier', label: 'Prettier - formatting' },
-    { value: 'biome', label: 'Biome - linting & formatting' },
-  ];
+  const options: ToolOption[] = BUILTIN_TOOL_OPTIONS.filter(({ value }) =>
+    enabledBuiltinToolSet.has(value),
+  );
 
   if (filteredExtraTools) {
     const normalize = (tool: ExtraTool) => ({
@@ -234,6 +271,10 @@ async function getTools(
         .filter((tool) => tool.order !== 'pre')
         .map(normalize),
     );
+  }
+
+  if (options.length === 0) {
+    return [];
   }
 
   return checkCancel<string[]>(
@@ -539,6 +580,7 @@ export async function create({
   mapRslintTemplate,
   version,
   noteInformation,
+  builtinTools,
   extraTools,
   extraSkills,
   argv: processArgv = process.argv,
@@ -567,6 +609,16 @@ export async function create({
   version?: Record<string, string> | string;
   noteInformation?: string[];
   /**
+   * Controls which built-in tools are available.
+   *
+   * Omit this option to enable all built-in tools. Pass an empty array to
+   * disable them, or list the built-in tools that should remain available.
+   * Additional tools are configured separately with `extraTools`.
+   *
+   * @default BUILTIN_TOOLS
+   */
+  builtinTools?: BuiltinToolName[];
+  /**
    * Specify additional tools.
    */
   extraTools?: ExtraTool[];
@@ -589,7 +641,7 @@ export async function create({
   const argv = parseArgv(processArgv);
 
   if (argv.help) {
-    logHelpMessage(name, templates, extraTools, extraSkills);
+    logHelpMessage(name, templates, builtinTools, extraTools, extraSkills);
     return;
   }
 
@@ -671,7 +723,7 @@ export async function create({
     return;
   }
 
-  const tools = await getTools(argv, extraTools, templateName);
+  const tools = await getTools(argv, builtinTools, extraTools, templateName);
   const skills = await getSkills(
     argv,
     extraSkills,

--- a/test/builtin-tools.test.ts
+++ b/test/builtin-tools.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as promptsActual from '@clack/prompts' with { rstest: 'importActual' };
+import { beforeEach, expect, rs, test } from '@rstest/core';
+import { create } from '../src';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, 'fixtures', 'basic');
+const testDir = path.join(fixturesDir, 'test-temp-output-builtin-tools');
+
+type PromptOption = {
+  value: string;
+  label?: string;
+  hint?: string;
+};
+
+const mocks = rs.hoisted(() => {
+  const state = {
+    toolPromptCount: 0,
+    toolPromptOptions: [] as PromptOption[],
+  };
+
+  const multiselect = rs.fn(
+    async (options: {
+      message?: string;
+      options?: Array<{ value: unknown; label?: string; hint?: string }>;
+    }) => {
+      if (options.message?.includes('Select additional tools')) {
+        state.toolPromptCount += 1;
+        state.toolPromptOptions = (options.options ?? []) as PromptOption[];
+      }
+      return [];
+    },
+  ) as typeof promptsActual.multiselect;
+
+  return { state, multiselect };
+});
+
+rs.mock('@clack/prompts', () => ({
+  ...promptsActual,
+  multiselect: mocks.multiselect,
+}));
+
+beforeEach(() => {
+  mocks.state.toolPromptCount = 0;
+  mocks.state.toolPromptOptions.length = 0;
+  rs.mocked(mocks.multiselect).mockClear();
+
+  if (fs.existsSync(testDir)) {
+    fs.rmSync(testDir, { recursive: true });
+  }
+  fs.mkdirSync(testDir, { recursive: true });
+
+  return () => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true });
+    }
+  };
+});
+
+test('should skip tools prompt when built-in tools are disabled', async () => {
+  const projectDir = path.join(testDir, 'no-tools');
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    builtinTools: [],
+    argv: ['node', 'test', '--dir', projectDir],
+  });
+
+  expect(mocks.state.toolPromptCount).toBe(0);
+});
+
+test('should keep extra tools in the prompt when built-in tools are disabled', async () => {
+  const projectDir = path.join(testDir, 'extra-tools');
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    builtinTools: [],
+    extraTools: [{ value: 'custom-tool', label: 'Custom Tool' }],
+    argv: ['node', 'test', '--dir', projectDir],
+  });
+
+  expect(mocks.state.toolPromptCount).toBe(1);
+  expect(mocks.state.toolPromptOptions).toEqual([
+    { value: 'custom-tool', label: 'Custom Tool', hint: undefined },
+  ]);
+});
+
+test('should only show configured built-in tools', async () => {
+  const projectDir = path.join(testDir, 'selected-tools');
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    builtinTools: ['rslint', 'prettier'],
+    argv: ['node', 'test', '--dir', projectDir],
+  });
+
+  expect(mocks.state.toolPromptOptions).toEqual([
+    { value: 'rslint', label: 'Rslint - linting' },
+    { value: 'prettier', label: 'Prettier - formatting' },
+  ]);
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -133,3 +133,28 @@ test('should skip tools selection', async () => {
   expect(fs.existsSync(path.join(projectDir, 'eslint.config.mjs'))).toBe(false);
   expect(fs.existsSync(path.join(projectDir, '.prettierrc'))).toBe(false);
 });
+
+test('should only accept enabled built-in tools', async () => {
+  const projectDir = path.join(testDir, 'enabled-builtin-tools');
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    builtinTools: ['prettier'],
+    argv: [
+      'node',
+      'test',
+      '--dir',
+      projectDir,
+      '--template',
+      'vanilla',
+      '--tools',
+      'eslint,prettier',
+    ],
+  });
+
+  expect(fs.existsSync(path.join(projectDir, 'eslint.config.mjs'))).toBe(false);
+  expect(fs.existsSync(path.join(projectDir, '.prettierrc'))).toBe(true);
+});

--- a/test/custom-tools.test.ts
+++ b/test/custom-tools.test.ts
@@ -281,3 +281,38 @@ test('should filter extra tools based on template name', async () => {
   // no-filter-tool should run because it has no `when`
   expect(noFilterToolCalled).toBe(true);
 });
+
+test('should keep extra tools when built-in tools are disabled', async () => {
+  const projectDir = path.join(testDir, 'extra-tool-without-builtin-tools');
+  let actionCalled = false;
+
+  await create({
+    name: 'test',
+    root: fixturesDir,
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    builtinTools: [],
+    extraTools: [
+      {
+        value: 'custom-action',
+        label: 'Custom Action',
+        action: () => {
+          actionCalled = true;
+        },
+      },
+    ],
+    argv: [
+      'node',
+      'test',
+      '--dir',
+      projectDir,
+      '--template',
+      'vanilla',
+      '--tools',
+      'eslint,custom-action',
+    ],
+  });
+
+  expect(actionCalled).toBe(true);
+  expect(fs.existsSync(path.join(projectDir, 'eslint.config.mjs'))).toBe(false);
+});

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -31,6 +31,72 @@ test('help message includes extra tools', async () => {
   expect(logOutput).toContain('eslint, rslint, biome, prettier, custom-tool');
 });
 
+test('help message excludes disabled built-in tools', async () => {
+  const logs: string[] = [];
+  const originalLog = logger.log;
+
+  logger.override({
+    log: (message?: unknown) => {
+      logs.push(String(message ?? ''));
+    },
+  });
+
+  try {
+    await create({
+      name: 'test',
+      root: '.',
+      templates: ['vanilla'],
+      getTemplateName: async () => 'vanilla',
+      builtinTools: [],
+      extraTools: [{ value: 'custom-tool', label: 'Custom Tool' }],
+      argv: ['node', 'test', '--help'],
+    });
+  } finally {
+    logger.override({
+      log: originalLog,
+    });
+  }
+
+  const logOutput = logs.join('\n');
+  expect(logOutput).toContain('--tools <tool>');
+  expect(logOutput).toContain('Optional tools:');
+  expect(logOutput).toContain('custom-tool');
+  expect(logOutput).not.toContain('eslint');
+  expect(logOutput).not.toContain('rslint');
+  expect(logOutput).not.toContain('biome');
+  expect(logOutput).not.toContain('prettier');
+});
+
+test('help message hides tools when all tools are disabled', async () => {
+  const logs: string[] = [];
+  const originalLog = logger.log;
+
+  logger.override({
+    log: (message?: unknown) => {
+      logs.push(String(message ?? ''));
+    },
+  });
+
+  try {
+    await create({
+      name: 'test',
+      root: '.',
+      templates: ['vanilla'],
+      getTemplateName: async () => 'vanilla',
+      builtinTools: [],
+      argv: ['node', 'test', '--help'],
+    });
+  } finally {
+    logger.override({
+      log: originalLog,
+    });
+  }
+
+  const logOutput = logs.join('\n');
+  expect(logOutput).not.toContain('--tools <tool>');
+  expect(logOutput).not.toContain('Optional tools:');
+});
+
 test('help message hides skill help when no optional skills are configured', async () => {
   const logs: string[] = [];
   const originalLog = logger.log;


### PR DESCRIPTION
This PR lets create-toolkit consumers control which built-in tools appear in the selection prompt and are accepted through `--tools`. The new `builtinTools` array defaults to all built-in tools, accepts a subset, and disables built-in tools when empty without affecting `extraTools`. Help output and tests are updated to cover the new behavior.