### PR TITLE
fix: inspect Git worktree status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -560,7 +560,10 @@ function initGit(cwd: string) {
     );
 
     // Reuse the current repository instead of creating a nested one.
-    if (repositoryCheck.exitCode === 0) {
+    if (
+      repositoryCheck.exitCode === 0 &&
+      repositoryCheck.stdout.trim() === 'true'
+    ) {
       return;
     }
 

--- a/test/custom-tools.test.ts
+++ b/test/custom-tools.test.ts
@@ -29,7 +29,7 @@ const mocks = rs.hoisted(() => {
       // rslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any,
     // rslint-disable-next-line @typescript-eslint/no-explicit-any
-    xSync: rs.fn(() => ({ stdout: '', stderr: '', exitCode: 0 })) as any,
+    xSync: rs.fn(() => ({ stdout: 'true\n', stderr: '', exitCode: 0 })) as any,
   };
 });
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -18,8 +18,8 @@ rs.mock('tinyexec', () => ({
   xSync: mocks.xSync,
 }));
 
-const createResult = (exitCode: number, stderr = '') => ({
-  stdout: '',
+const createResult = (exitCode: number, stdout = '', stderr = '') => ({
+  stdout,
   stderr,
   exitCode,
 });
@@ -71,7 +71,7 @@ test('should initialize a Git repository by default', async () => {
 
 test('should reuse an existing Git repository', async () => {
   const projectDir = path.join(testDir, 'existing');
-  rs.mocked(mocks.xSync).mockReturnValue(createResult(0));
+  rs.mocked(mocks.xSync).mockReturnValue(createResult(0, 'true\n'));
 
   await createProject(projectDir);
 
@@ -81,6 +81,17 @@ test('should reuse an existing Git repository', async () => {
     ['rev-parse', '--is-inside-work-tree'],
     { nodeOptions: { cwd: projectDir } },
   );
+});
+
+test('should initialize Git when the current repository is bare', async () => {
+  const projectDir = path.join(testDir, 'bare');
+  rs.mocked(mocks.xSync).mockReturnValueOnce(createResult(0, 'false\n'));
+
+  await createProject(projectDir);
+
+  expect(mocks.xSync).toHaveBeenNthCalledWith(2, 'git', ['init'], {
+    nodeOptions: { cwd: projectDir },
+  });
 });
 
 test('should skip Git initialization when disabled', async () => {
@@ -96,7 +107,7 @@ test('should continue when Git initialization fails', async () => {
   rs.mocked(mocks.xSync).mockImplementation((_command, args) =>
     args[0] === 'rev-parse'
       ? createResult(128)
-      : createResult(1, 'Git is unavailable'),
+      : createResult(1, '', 'Git is unavailable'),
   );
 
   await expect(createProject(projectDir)).resolves.toBeUndefined();

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -69,7 +69,7 @@ const mocks = rs.hoisted(() => {
 
   const xSync = rs.fn((command: string, args: string[], options: unknown) => {
     return {
-      stdout: '',
+      stdout: 'true\n',
       stderr: '',
       exitCode: 0,
     };


### PR DESCRIPTION
`git rev-parse --is-inside-work-tree` exits successfully while printing `false` inside a bare repository, which caused project creation to skip `git init`.

This PR checks the command output before reusing a worktree and adds coverage for both `true` and `false` results.

## Related Links

- https://github.com/rstackjs/create-toolkit/pull/158