### PR TITLE
fix: improve CLI help output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,41 +211,52 @@ function logHelpMessage(
   }
 
   const hasTools = toolsList.length > 0;
-  const gitOptionLine = git
-    ? '      --no-git              skip Git repository initialization\n'
-    : '';
-  const toolsOptionLine = hasTools
-    ? '      --tools <tool>        add additional tools, comma separated\n'
-    : '';
-  const skillsOptionLine = hasSkills
-    ? '      --skill <skill>       add optional skills, comma separated\n'
-    : '';
-  const optionalToolsSection = hasTools
-    ? `
-    Optional tools:
-       ${toolsList.join(', ')}`
-    : '';
-  const optionalSkillsSection = hasSkills
-    ? `
-   Optional skills:
-      ${skillsList.join(', ')}`
-    : '';
+  const options: [flags: string, description: string][] = [
+    ['-h, --help', 'display help for command'],
+    ['-d, --dir <dir>', 'create project in specified directory'],
+    ['-t, --template <tpl>', 'specify the template to use'],
+  ];
 
-  logger.log(`
-   Usage: create-${name} [dir] [options]
+  if (git) {
+    options.push(['--no-git', 'skip Git repository initialization']);
+  }
+  if (hasTools) {
+    options.push(['--tools <tool>', 'add additional tools, comma separated']);
+  }
+  if (hasSkills) {
+    options.push(['--skill <skill>', 'add optional skills, comma separated']);
+  }
 
-   Options:
-   
-     -h, --help            display help for command
-      -d, --dir <dir>       create project in specified directory
-      -t, --template <tpl>  specify the template to use
-${gitOptionLine}${toolsOptionLine}${skillsOptionLine}      --override            override files in target directory
-      --packageName <name>  specify the package name
-      --template-version <ver>  specify the npm template version
-    
-    Available templates:
-      ${templates.join(', ')}${optionalToolsSection}${optionalSkillsSection}
-`);
+  options.push(
+    ['--override', 'override files in target directory'],
+    ['--package-name <name>', 'specify the package name'],
+    ['--template-version <ver>', 'specify the npm template version'],
+  );
+
+  const optionWidth = Math.max(...options.map(([flags]) => flags.length));
+  const optionLines = options
+    .map(
+      ([flags, description]) =>
+        `  ${flags.padEnd(optionWidth)}  ${description}`,
+    )
+    .join('\n');
+  const helpSections = [
+    `Usage: create-${name} [dir] [options]`,
+    '',
+    'Options:',
+    optionLines,
+    '',
+    `Available templates: ${templates.join(', ')}`,
+  ];
+
+  if (hasTools) {
+    helpSections.push('', `Optional tools: ${toolsList.join(', ')}`);
+  }
+  if (hasSkills) {
+    helpSections.push('', `Optional skills: ${skillsList.join(', ')}`);
+  }
+
+  logger.log(helpSections.join('\n'));
 }
 
 async function getTools(
@@ -747,6 +758,13 @@ export async function create({
    */
   argv?: string[];
 }) {
+  const argv = parseArgv(processArgv);
+
+  if (argv.help) {
+    logHelpMessage(name, templates, git, builtinTools, extraTools, extraSkills);
+    return;
+  }
+
   logger.greet(`\n◆  Create ${upperFirst(name)} Project`);
 
   const { isAgent } = await determineAgent();
@@ -757,13 +775,7 @@ export async function create({
     );
   }
 
-  const argv = parseArgv(processArgv);
   const gitEnabled = git && argv.git !== false;
-
-  if (argv.help) {
-    logHelpMessage(name, templates, git, builtinTools, extraTools, extraSkills);
-    return;
-  }
 
   const cwd = process.cwd();
   const pkgInfo = pkgFromUserAgent(process.env.npm_config_user_agent);

--- a/test/__snapshots__/help.test.ts.snap
+++ b/test/__snapshots__/help.test.ts.snap
@@ -1,0 +1,20 @@
+// Rstest Snapshot v1
+
+exports[`help message uses compact, aligned output 1`] = `
+[
+  [
+    "Usage: create-test [dir] [options]
+
+Options:
+  -h, --help                display help for command
+  -d, --dir <dir>           create project in specified directory
+  -t, --template <tpl>      specify the template to use
+  --no-git                  skip Git repository initialization
+  --override                override files in target directory
+  --package-name <name>     specify the package name
+  --template-version <ver>  specify the npm template version
+
+Available templates: vanilla",
+  ],
+]
+`;

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -1,6 +1,25 @@
-import { expect, test } from 'rstack/test';
+import { afterEach, expect, rs, test } from 'rstack/test';
 import { logger } from 'rslog';
 import { create } from '../src';
+
+afterEach(() => {
+  rs.restoreAllMocks();
+});
+
+test('help message uses compact, aligned output', async () => {
+  const log = rs.spyOn(logger, 'log').mockImplementation(() => {});
+
+  await create({
+    name: 'test',
+    root: '.',
+    templates: ['vanilla'],
+    getTemplateName: async () => 'vanilla',
+    builtinTools: [],
+    argv: ['node', 'test', '--help'],
+  });
+
+  expect(log.mock.calls).toMatchSnapshot();
+});
 
 test('help message includes the Git opt-out option', async () => {
   const logs: string[] = [];
@@ -26,9 +45,7 @@ test('help message includes the Git opt-out option', async () => {
     });
   }
 
-  expect(logs.join('\n')).toContain(
-    '--no-git              skip Git repository initialization',
-  );
+  expect(logs.join('\n')).toContain('--no-git');
 });
 
 test('help message hides the Git opt-out option when Git is disabled', async () => {


### PR DESCRIPTION
This PR makes generated CLI help easier to scan by omitting the project greeting for help requests and aligning option labels and descriptions.

It also exposes the kebab-case `--package-name` flag and formats template, tool, and skill lists inline while retaining camel-case parsing compatibility.