### PR TITLE
chore: upgrade Rstack CLI to v0.5.1

### DIFF
--- a/.agents/skills/rstack-cli-best-practices/SKILL.md
+++ b/.agents/skills/rstack-cli-best-practices/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: rstack-cli-best-practices
+description: Guidance for Rstack CLI work involving `rs` commands, `rstack.config.*`, package APIs, or Rstack-based projects and tooling.
+---
+
+# Rstack CLI Best Practices
+
+Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one
+config file, and a consistent workflow for the Rstack JavaScript toolchain.
+
+It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
+
+## ALWAYS read installed docs before working
+
+Before any Rstack work, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
+
+Model knowledge can be outdated; the installed documentation is the source of truth for the project's Rstack version.
+
+1. Start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task before proposing or making changes.
+
+2. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
+
+If the bundled docs are not available at that path, locate the installed `rstack` package.
+
+If they are still unavailable, verify that `rstack` is installed, and use CLI help plus the online [Rstack documentation](https://rstack.rs/) as a fallback.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "^11.3.6",
     "minimist": "^1.2.8",
     "rimraf": "^6.1.3",
-    "rstack": "^0.5.0",
+    "rstack": "^0.5.1",
     "rslog": "^2.2.0",
     "tinyexec": "^1.2.4",
     "typescript": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "^11.3.6",
     "minimist": "^1.2.8",
     "rimraf": "^6.1.3",
-    "rstack": "^0.4.0",
+    "rstack": "^0.5.0",
     "rslog": "^2.2.0",
     "tinyexec": "^1.2.4",
     "typescript": "^7.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       rstack:
-        specifier: ^0.4.0
-        version: 0.4.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2)
+        specifier: ^0.5.0
+        version: 0.5.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2)
       tinyexec:
         specifier: ^1.2.4
         version: 1.2.4
@@ -307,6 +307,92 @@ packages:
       '@swc/helpers':
         optional: true
 
+  '@rstackjs/cli-darwin-arm64@0.5.0':
+    resolution: {integrity: sha512-jHjafWvdboIfwykM+yYuPc9tNZfuB+zMqiYp5oWXVEU5qd6yaIwCFu2nfM3vRh5aos0vIi0Nk+os4aOKSdK9Fg==}
+    engines: {node: '>=22.12.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rstackjs/cli-darwin-x64@0.5.0':
+    resolution: {integrity: sha512-jMwzBTa+WTMYUd8v81WekOAgkclG7L7ocACf11oCjHDdnWyUjazACEKumUHZSjC5hB5dNt/B7esu711XoYpoUQ==}
+    engines: {node: '>=22.12.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rstackjs/cli-linux-arm64-gnu@0.5.0':
+    resolution: {integrity: sha512-R+XJM5YoVsA3TfbhGyNdQ42ocpUgC2Tfe/VKOUwQ3SsIFbHLRepWTRu882HklBP4dfgaN0HA38iQ1Iy+bb9qsQ==}
+    engines: {node: '>=22.12.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rstackjs/cli-linux-arm64-musl@0.5.0':
+    resolution: {integrity: sha512-yc8YpwJn3SvsUHBfZnv37c1ttCEefcbtWdUA28sPzCZpM2G+IHc3bQZN+fJ2OyaaofImMXd1vkrmAIgYhEkn5g==}
+    engines: {node: '>=22.12.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rstackjs/cli-linux-ppc64-gnu@0.5.0':
+    resolution: {integrity: sha512-g3vHo/G29XYKgIUTI5dUn4JYeAPOtHuWcPyrw5K2WL4U8DUncI0mvG71fviCaMw4yOB743OOSsUlvmMKB3A2lQ==}
+    engines: {node: '>=22.12.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rstackjs/cli-linux-riscv64-gnu@0.5.0':
+    resolution: {integrity: sha512-fLmOfBSUfpe+Yv54GcGTGhqv9bbbRwZVPUz+oe0MfpFo+I34NK/36Q1C9IikrfCs8Cra8pCEvzj5hdUb68g3Sw==}
+    engines: {node: '>=22.12.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rstackjs/cli-linux-riscv64-musl@0.5.0':
+    resolution: {integrity: sha512-N3ZU787pFB9ySTmYwAVfubYESXbL+i1LNGTb1hUDLPdsNGMujs8n5atTHHuLjjVfBpWqo8jAjt+o1ZohCf2CxA==}
+    engines: {node: '>=22.12.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rstackjs/cli-linux-s390x-gnu@0.5.0':
+    resolution: {integrity: sha512-H/AkCZ7320OKGRq/VX6UcWHS1fNhKcI6ygM8xAShIstud5YoImHkafHKsAR7e8tlG+7GtTP7OIXV/4ins6bSvA==}
+    engines: {node: '>=22.12.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rstackjs/cli-linux-x64-gnu@0.5.0':
+    resolution: {integrity: sha512-aeE0BcXW0t3cEJcP3809LCnLtaaeOwKGaFm/yqI48OS9mHKOZxxEFM+Sz9vSHQPs0mZh/u32PBOeKts+EHBSwg==}
+    engines: {node: '>=22.12.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rstackjs/cli-linux-x64-musl@0.5.0':
+    resolution: {integrity: sha512-QSZSSUUewOqa3USWw0tFcJBO5wnhJHZRR2QJSTK/D4uvtqeN/Gj2Acp+oN1dlVP0Gb2jjqEg/Iwemuynbw9kLw==}
+    engines: {node: '>=22.12.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rstackjs/cli-win32-arm64-msvc@0.5.0':
+    resolution: {integrity: sha512-ycrw1yE41P9MgAXwGxsNYlsCqbY+ISH45/sdwsAKM0dM72PphGOKVFqWlqGGQ5vZN+l/bmlncp+H6uj0IraMYw==}
+    engines: {node: '>=22.12.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rstackjs/cli-win32-ia32-msvc@0.5.0':
+    resolution: {integrity: sha512-J6bThaKLw+wBJp9X1w9ATQyx3m2YiZSYfInh6wpNDEJ55QxJsnU4DxnvKTSTYuIwg+SA7Zjq9CRCMcO6QXJcZg==}
+    engines: {node: '>=22.12.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rstackjs/cli-win32-x64-msvc@0.5.0':
+    resolution: {integrity: sha512-onON8Tlg+j3QXLL8oE74vP/0XC6MJjpt5qvF4vJFqApiMUpW9Nm0mRrOJWE2QEen6jQXO3x5sNxir+qlUdbODQ==}
+    engines: {node: '>=22.12.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@rstest/core@0.11.6':
     resolution: {integrity: sha512-P3wgYGDF3JmhapwN3p4DnbNV9N6+E+dlbp0coT1lAuXN5Po6bHeP/rduGLsTUIX85qWxmJD7ekF7nlOKm9RoOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -501,69 +587,69 @@ packages:
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@yuku-parser/binding-android-arm64@0.8.3':
-    resolution: {integrity: sha512-vySYRsMeul9ssvxeHdxgS9ZUIcq7gqljWNqgokjJE0uQWvVvOprihJ6hOsiifVqWsla0BMc3vAFBvNS9QqCw7g==}
+  '@yuku-parser/binding-android-arm64@0.8.4':
+    resolution: {integrity: sha512-+HIMmv08Zrh9ugIAEMnKBMMePOl7CDxrjc8Vui1+GG2TJHM1yI1+3wo1pnXB6Nj2IiHugDkQw8ycUI6SA2EUkQ==}
     cpu: [arm64]
     os: [android]
 
-  '@yuku-parser/binding-darwin-arm64@0.8.3':
-    resolution: {integrity: sha512-+wpB/wqhiZ685Y77I+lj6v9pHSAJ3Y+QMHJmvch0Q0ahIMbNwtKk3s54MhtjCMKO1qpjPbyN/PjuHDg2hbKaVQ==}
+  '@yuku-parser/binding-darwin-arm64@0.8.4':
+    resolution: {integrity: sha512-Elf/B/2m3OsyvxoQnBk8Dtu+9csHkzBNs5Yv9GbHjT3x0kVKNWjFusyZgm41VwxcPDqdpRi8tWxNX7OqXkmf/A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.8.3':
-    resolution: {integrity: sha512-jKqiWejj4zVy7pPtEGu4/Ty+pG1h7ooQOXIkm7shKZTSwTU9X8X+eoH11uIeKHZi2SQWV0GhNz0J56eerseysQ==}
+  '@yuku-parser/binding-darwin-x64@0.8.4':
+    resolution: {integrity: sha512-CjZuMoXnL5XUkVpDqh4WDPwpAw8CwmtHHnTerGkS45So/sNuwkXdyIAEqqIZfaLopi5W/V9NApAT2md9XizjsQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.8.3':
-    resolution: {integrity: sha512-FC7zSwzFzd4z9bsId07CiHLR+Iw6yW/LzIQhL5AUtPUuVXLgEyx0rilgbRUYkl1CT3GJcLpkh63WuPZUSgCDzw==}
+  '@yuku-parser/binding-freebsd-x64@0.8.4':
+    resolution: {integrity: sha512-ibLKORdz71iI4Vs+fyFgvwQ51P5XcxJIyQLa8cSEWqwptRdo+BTcZHIQEcZnFDPUuvmJ19RRH9CoiJdfhr7pZw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
-    resolution: {integrity: sha512-So61j88b9/ygDnUPlWCm1EUPw4HSxAyDjrNHKgud5N3aRDQ3kw94nW7TriXbo7GBXID9oBHCMNm1r1Fof/Df5Q==}
+  '@yuku-parser/binding-linux-arm-gnu@0.8.4':
+    resolution: {integrity: sha512-Fo3r5fYhGDcFnl+KN+L9PgtiQPS4AIE1n1mG1o5jZ11p7g5yZ/1EjLFmSHAUsoXreun8KjTsFjEL7P1Sb93PZQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.8.3':
-    resolution: {integrity: sha512-Nmnn20yJvSSKL8ZdtqReBRSGCDkSMqR5jEk/Sk/cdIdZmqVD49Z6M7w2GbMjdrxMI1MBPbsWFMMWxa93cd5t5g==}
+  '@yuku-parser/binding-linux-arm-musl@0.8.4':
+    resolution: {integrity: sha512-BEB31vUEgXPWf7WkoMPSzzJhpC/wWCBXyysRCCPsw47BJ/OtbQsvJbxX9fFDuSRLy3kbyIV/WbdUTgbQ9COxiw==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
-    resolution: {integrity: sha512-Lfgw7AXJ0rxu6BMPGgfc8HLJWEIr8BHhCzcQp/75k+NM90uCLkHlBNqIg/K42KlSvBgAvu9euOvjdswib+4qJA==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.4':
+    resolution: {integrity: sha512-xGLCRcHn9xVz7JVNyyKtiNJSf503qtUmih9XVSsghgzOmiKUMnHObs69OMMwXN3788tg1jsl11fNjjQlB8idMA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
-    resolution: {integrity: sha512-cfRyu87xsJ0tFkHNsnMC4Rq6+xsFJ6i2dc4VAH52d2qLvykEJU/Mdi3ul1O2PyOApX/LoLT3uQZ0fWs3D5XE4w==}
+  '@yuku-parser/binding-linux-arm64-musl@0.8.4':
+    resolution: {integrity: sha512-3kNRi8NJT2q6FQRVCUFHIQ99+kXdi8cVJEEUi6+xtFqpMgNrZNnbgAj28ILsDC7zmclaU+v47eUCeJoKLSCbww==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
-    resolution: {integrity: sha512-GcQQCUuYxbm6P1n+io/A50rvWKDeWHutIp6rW0ycDOZuEQjOb8hDVgS88+NDyOnd9FfS0/Z6GXopcRFDyKpzOg==}
+  '@yuku-parser/binding-linux-x64-gnu@0.8.4':
+    resolution: {integrity: sha512-isi62oMy94Z3OXwGs2l2rkqRiRyqLmfHeTRHpA/uWZbsNhnm7IdVvkF7e7wHNKAtd5jwGzOqYSroxKv2fOm7Cw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.8.3':
-    resolution: {integrity: sha512-rMkImBGZzg7GZlj8krYtdiezyjYI4igjKWMut5T65jHyNWFigMQrEpn9mDIBflloW9FKhGE3mN6yTZ/N+4HRwg==}
+  '@yuku-parser/binding-linux-x64-musl@0.8.4':
+    resolution: {integrity: sha512-9RsEw2xYHqU/pjSRBTOupWN3sF8uz9stjJdARfz6o0llvF+yfrj5QHmTiocGGBeAI80fvKmDtr2RIQClUzAPcA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.8.3':
-    resolution: {integrity: sha512-/2Pl2cAzCXWxah8FqJapEj/ikpt9cEutEZFCa0hnbfrshkn5+C+aBM3ZDq62d1jsgQjBMmqr5HVhJUA4OAG/Tg==}
+  '@yuku-parser/binding-win32-arm64@0.8.4':
+    resolution: {integrity: sha512-VEZHo9rEGOBKR20sA3vCO00aQvwWND5aLu7YxeX+YupMZJh9hd1f17AbClJN37Q2iL1PCHht+wDTOKX6tZYqXg==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.8.3':
-    resolution: {integrity: sha512-Ntnvjoan9jnfLhn7Kn3h8j/bhsbVdQSVmKUqFULKtmwImLCJVHOJbLL4qbEJyrOQ7r/FBL1/c/dRvx/AQWzzXg==}
+  '@yuku-parser/binding-win32-x64@0.8.4':
+    resolution: {integrity: sha512-PeH3VzN1feGjPtDpVEAqf000fPT+nxtw/696LKp/5Z9RJi/MaXpB636QC+5QtrAPSoEnIkyEe+c+mq2QLZPWBA==}
     cpu: [x64]
     os: [win32]
 
@@ -734,8 +820,8 @@ packages:
     resolution: {integrity: sha512-aTYPzpoq1NrQYB8uK3mXEZgXoLva5lqMfnFNrPLZALsIx7vD1Q+HTp+fuu2aRHV3PJTg63ARDZ8MT0Lth4SoNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  rstack@0.4.0:
-    resolution: {integrity: sha512-D+UoBYDhmoWbvCMCfVEFQOe+wdrPPAZXYCUppDVy/KRGC8UOKruyjlTzh3IA9zCzGT7gVDziIQXBuhULmJJpgA==}
+  rstack@0.5.0:
+    resolution: {integrity: sha512-O+LHlNEfMf7C9EWWcAdt+KQiVyaR8nN0AjEaj4h4mv0G14BubZZ3lPuycFoZDwgGQd6Zstv7SIs/QHqfeba3Zg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -802,8 +888,8 @@ packages:
   yuku-ast@0.8.4:
     resolution: {integrity: sha512-s7EWfWIQkaGmsGnyr/BU0jli9YTN5TvrKIsSmALyRD9elumDQInuhv0BrVObENKVCxr9W3Ikmnx5u02KvfuUmw==}
 
-  yuku-parser@0.8.3:
-    resolution: {integrity: sha512-KPQcpF9aj77ywlJBIkQWCQ9DObdxnCA8AJdUOmA5CZZx042Xt4+dvbQmPJfWxF3E+KG5dVAZ2fBKuDJ8VsKWgA==}
+  yuku-parser@0.8.4:
+    resolution: {integrity: sha512-sw41wouvT5rUmLIp87hmvm5vtF+MRSI3x6yjq6xqpYmtkQj+Ht6N7xRQ8lMhLv8N7JAzughGj0Rfi0jQRSu9HQ==}
 
 snapshots:
 
@@ -1032,6 +1118,45 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
+  '@rstackjs/cli-darwin-arm64@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-darwin-x64@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-arm64-gnu@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-arm64-musl@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-ppc64-gnu@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-riscv64-gnu@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-riscv64-musl@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-s390x-gnu@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-x64-gnu@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-linux-x64-musl@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-win32-arm64-msvc@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-win32-ia32-msvc@0.5.0':
+    optional: true
+
+  '@rstackjs/cli-win32-x64-msvc@0.5.0':
+    optional: true
+
   '@rstest/core@0.11.6':
     dependencies:
       '@rsbuild/core': 2.1.10
@@ -1174,40 +1299,40 @@ snapshots:
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@yuku-parser/binding-android-arm64@0.8.3':
+  '@yuku-parser/binding-android-arm64@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.8.3':
+  '@yuku-parser/binding-darwin-arm64@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.8.3':
+  '@yuku-parser/binding-darwin-x64@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.8.3':
+  '@yuku-parser/binding-freebsd-x64@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
+  '@yuku-parser/binding-linux-arm-gnu@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.8.3':
+  '@yuku-parser/binding-linux-arm-musl@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
+  '@yuku-parser/binding-linux-arm64-musl@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
+  '@yuku-parser/binding-linux-x64-gnu@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.8.3':
+  '@yuku-parser/binding-linux-x64-musl@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.8.3':
+  '@yuku-parser/binding-win32-arm64@0.8.4':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.8.3':
+  '@yuku-parser/binding-win32-x64@0.8.4':
     optional: true
 
   '@yuku-toolchain/types@0.8.4': {}
@@ -1345,7 +1470,7 @@ snapshots:
 
   rslog@2.2.0: {}
 
-  rstack@0.4.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2):
+  rstack@0.5.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2):
     dependencies:
       '@rsbuild/core': 2.1.10
       '@rslib/core': 1.0.0-beta.2(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2)
@@ -1353,7 +1478,21 @@ snapshots:
       '@rstest/core': 0.11.6
       prettier: 3.9.6
       tinypool: 2.1.0
-      yuku-parser: 0.8.3
+      yuku-parser: 0.8.4
+    optionalDependencies:
+      '@rstackjs/cli-darwin-arm64': 0.5.0
+      '@rstackjs/cli-darwin-x64': 0.5.0
+      '@rstackjs/cli-linux-arm64-gnu': 0.5.0
+      '@rstackjs/cli-linux-arm64-musl': 0.5.0
+      '@rstackjs/cli-linux-ppc64-gnu': 0.5.0
+      '@rstackjs/cli-linux-riscv64-gnu': 0.5.0
+      '@rstackjs/cli-linux-riscv64-musl': 0.5.0
+      '@rstackjs/cli-linux-s390x-gnu': 0.5.0
+      '@rstackjs/cli-linux-x64-gnu': 0.5.0
+      '@rstackjs/cli-linux-x64-musl': 0.5.0
+      '@rstackjs/cli-win32-arm64-msvc': 0.5.0
+      '@rstackjs/cli-win32-ia32-msvc': 0.5.0
+      '@rstackjs/cli-win32-x64-msvc': 0.5.0
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@module-federation/runtime-tools'
@@ -1418,20 +1557,20 @@ snapshots:
     dependencies:
       '@yuku-toolchain/types': 0.8.4
 
-  yuku-parser@0.8.3:
+  yuku-parser@0.8.4:
     dependencies:
       '@yuku-toolchain/types': 0.8.4
       yuku-ast: 0.8.4
     optionalDependencies:
-      '@yuku-parser/binding-android-arm64': 0.8.3
-      '@yuku-parser/binding-darwin-arm64': 0.8.3
-      '@yuku-parser/binding-darwin-x64': 0.8.3
-      '@yuku-parser/binding-freebsd-x64': 0.8.3
-      '@yuku-parser/binding-linux-arm-gnu': 0.8.3
-      '@yuku-parser/binding-linux-arm-musl': 0.8.3
-      '@yuku-parser/binding-linux-arm64-gnu': 0.8.3
-      '@yuku-parser/binding-linux-arm64-musl': 0.8.3
-      '@yuku-parser/binding-linux-x64-gnu': 0.8.3
-      '@yuku-parser/binding-linux-x64-musl': 0.8.3
-      '@yuku-parser/binding-win32-arm64': 0.8.3
-      '@yuku-parser/binding-win32-x64': 0.8.3
+      '@yuku-parser/binding-android-arm64': 0.8.4
+      '@yuku-parser/binding-darwin-arm64': 0.8.4
+      '@yuku-parser/binding-darwin-x64': 0.8.4
+      '@yuku-parser/binding-freebsd-x64': 0.8.4
+      '@yuku-parser/binding-linux-arm-gnu': 0.8.4
+      '@yuku-parser/binding-linux-arm-musl': 0.8.4
+      '@yuku-parser/binding-linux-arm64-gnu': 0.8.4
+      '@yuku-parser/binding-linux-arm64-musl': 0.8.4
+      '@yuku-parser/binding-linux-x64-gnu': 0.8.4
+      '@yuku-parser/binding-linux-x64-musl': 0.8.4
+      '@yuku-parser/binding-win32-arm64': 0.8.4
+      '@yuku-parser/binding-win32-x64': 0.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       rstack:
-        specifier: ^0.5.0
-        version: 0.5.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2)
+        specifier: ^0.5.1
+        version: 0.5.1(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2)
       tinyexec:
         specifier: ^1.2.4
         version: 1.2.4
@@ -307,88 +307,88 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rstackjs/cli-darwin-arm64@0.5.0':
-    resolution: {integrity: sha512-jHjafWvdboIfwykM+yYuPc9tNZfuB+zMqiYp5oWXVEU5qd6yaIwCFu2nfM3vRh5aos0vIi0Nk+os4aOKSdK9Fg==}
+  '@rstackjs/cli-darwin-arm64@0.5.1':
+    resolution: {integrity: sha512-3ExxD49AhN/kWUQtTVIBoc2dX5TRyOLwT745qfEUNIrordjmHfMtmG4RXI6jmoGgMhmCuwvkWQzBiDbBdn7AUQ==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rstackjs/cli-darwin-x64@0.5.0':
-    resolution: {integrity: sha512-jMwzBTa+WTMYUd8v81WekOAgkclG7L7ocACf11oCjHDdnWyUjazACEKumUHZSjC5hB5dNt/B7esu711XoYpoUQ==}
+  '@rstackjs/cli-darwin-x64@0.5.1':
+    resolution: {integrity: sha512-KuHdqxylPTlCeKadwDNffRCFJjqcCludVr/M0px9xI2lzlCj1cMAwXjxK+kOOU8nb9hJGiG5/305zc59CqcDjw==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@rstackjs/cli-linux-arm64-gnu@0.5.0':
-    resolution: {integrity: sha512-R+XJM5YoVsA3TfbhGyNdQ42ocpUgC2Tfe/VKOUwQ3SsIFbHLRepWTRu882HklBP4dfgaN0HA38iQ1Iy+bb9qsQ==}
+  '@rstackjs/cli-linux-arm64-gnu@0.5.1':
+    resolution: {integrity: sha512-VQjUk5hnU0i8UVt0FcvLulYUhl5qs/gf1ONe0639jEvehkVgZO3p0vloQAeNVylmW0SWFt3Com8urZPJVQS2DA==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-arm64-musl@0.5.0':
-    resolution: {integrity: sha512-yc8YpwJn3SvsUHBfZnv37c1ttCEefcbtWdUA28sPzCZpM2G+IHc3bQZN+fJ2OyaaofImMXd1vkrmAIgYhEkn5g==}
+  '@rstackjs/cli-linux-arm64-musl@0.5.1':
+    resolution: {integrity: sha512-l7o9IaJGkiF3/fJ6NHAhm0EdQi/Iim6xGw1EkvVgjSCwR8eAn56ans98QRGe1FK2s5xgH+tTZxbE0wmCJ4gVMg==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-linux-ppc64-gnu@0.5.0':
-    resolution: {integrity: sha512-g3vHo/G29XYKgIUTI5dUn4JYeAPOtHuWcPyrw5K2WL4U8DUncI0mvG71fviCaMw4yOB743OOSsUlvmMKB3A2lQ==}
+  '@rstackjs/cli-linux-ppc64-gnu@0.5.1':
+    resolution: {integrity: sha512-+WQNQf3yTquLh4mr7w+HndPuRIZIHXDvQrgkmaXRwnjY90eE3N9fHcFD+8mKctUglRDPyefFH8Q+3/yj6dj6CA==}
     engines: {node: '>=22.12.0'}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-riscv64-gnu@0.5.0':
-    resolution: {integrity: sha512-fLmOfBSUfpe+Yv54GcGTGhqv9bbbRwZVPUz+oe0MfpFo+I34NK/36Q1C9IikrfCs8Cra8pCEvzj5hdUb68g3Sw==}
+  '@rstackjs/cli-linux-riscv64-gnu@0.5.1':
+    resolution: {integrity: sha512-/GsIqO/EcxB29LGoiyIWAgGYuWvcjmtZztyf9H/z1UOCc6Gb1Ox6OVFaRljGf/SuNnlhsBlvZXt2kzsnbXDfMg==}
     engines: {node: '>=22.12.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-riscv64-musl@0.5.0':
-    resolution: {integrity: sha512-N3ZU787pFB9ySTmYwAVfubYESXbL+i1LNGTb1hUDLPdsNGMujs8n5atTHHuLjjVfBpWqo8jAjt+o1ZohCf2CxA==}
+  '@rstackjs/cli-linux-riscv64-musl@0.5.1':
+    resolution: {integrity: sha512-zC4YhRdJrTrl0bOdPEdemZPow+K9hhXaiDXNh1U8QSETVln8zhQ97RiguVvZZw///wFZjfuxtVuK2F9H9++i3w==}
     engines: {node: '>=22.12.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-linux-s390x-gnu@0.5.0':
-    resolution: {integrity: sha512-H/AkCZ7320OKGRq/VX6UcWHS1fNhKcI6ygM8xAShIstud5YoImHkafHKsAR7e8tlG+7GtTP7OIXV/4ins6bSvA==}
+  '@rstackjs/cli-linux-s390x-gnu@0.5.1':
+    resolution: {integrity: sha512-O8yX/2mHX8R7zCXA3uAM/AMKhTufb+bMrRB1KyPDRUmYDqk0iUH6dewG9R7MYQImVf/STGPDGGJRsAc1Gnp6Lw==}
     engines: {node: '>=22.12.0'}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-x64-gnu@0.5.0':
-    resolution: {integrity: sha512-aeE0BcXW0t3cEJcP3809LCnLtaaeOwKGaFm/yqI48OS9mHKOZxxEFM+Sz9vSHQPs0mZh/u32PBOeKts+EHBSwg==}
+  '@rstackjs/cli-linux-x64-gnu@0.5.1':
+    resolution: {integrity: sha512-Y6BykGWNy4YsNYE69Z2Ob8ku7NYoywzg5YUmNnnOJXy1g87F6zgmOZhgLQ06bqEEUiBhJedgata6kODq8d/YhA==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rstackjs/cli-linux-x64-musl@0.5.0':
-    resolution: {integrity: sha512-QSZSSUUewOqa3USWw0tFcJBO5wnhJHZRR2QJSTK/D4uvtqeN/Gj2Acp+oN1dlVP0Gb2jjqEg/Iwemuynbw9kLw==}
+  '@rstackjs/cli-linux-x64-musl@0.5.1':
+    resolution: {integrity: sha512-JPqzSzmEZno+3Fhbr+6qiflOAUsl/qFlZV/KX16vQTVHW2nexF8GX/fQZIiMPAwmAD8u2BPk8/k4F4NrS5JUBA==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rstackjs/cli-win32-arm64-msvc@0.5.0':
-    resolution: {integrity: sha512-ycrw1yE41P9MgAXwGxsNYlsCqbY+ISH45/sdwsAKM0dM72PphGOKVFqWlqGGQ5vZN+l/bmlncp+H6uj0IraMYw==}
+  '@rstackjs/cli-win32-arm64-msvc@0.5.1':
+    resolution: {integrity: sha512-qi3UAfstpLf/JKpPKKS4ZQk491Mrx+lh1w2VOF2H2A/xghPLp3/z/uewu7ul+83JykFDXdswCd1pVuzN37wDcA==}
     engines: {node: '>=22.12.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@rstackjs/cli-win32-ia32-msvc@0.5.0':
-    resolution: {integrity: sha512-J6bThaKLw+wBJp9X1w9ATQyx3m2YiZSYfInh6wpNDEJ55QxJsnU4DxnvKTSTYuIwg+SA7Zjq9CRCMcO6QXJcZg==}
+  '@rstackjs/cli-win32-ia32-msvc@0.5.1':
+    resolution: {integrity: sha512-f0T2aw2EyM/ojflmd8SLnqahbTg6Vat3hA9sDqVfS2WclEuYFyO06Fmq6oePoU/yDzoumvIwjZgGWPvvaguxug==}
     engines: {node: '>=22.12.0'}
     cpu: [ia32]
     os: [win32]
 
-  '@rstackjs/cli-win32-x64-msvc@0.5.0':
-    resolution: {integrity: sha512-onON8Tlg+j3QXLL8oE74vP/0XC6MJjpt5qvF4vJFqApiMUpW9Nm0mRrOJWE2QEen6jQXO3x5sNxir+qlUdbODQ==}
+  '@rstackjs/cli-win32-x64-msvc@0.5.1':
+    resolution: {integrity: sha512-vWH5t7tjZWcKOVTwWJeVx2aRLp4gCqOEMlWtp3vnCNmkdDYe61VRnO1ncY57eSaj9eD2GHe3QZkFGZf/bZWexA==}
     engines: {node: '>=22.12.0'}
     cpu: [x64]
     os: [win32]
@@ -820,8 +820,8 @@ packages:
     resolution: {integrity: sha512-aTYPzpoq1NrQYB8uK3mXEZgXoLva5lqMfnFNrPLZALsIx7vD1Q+HTp+fuu2aRHV3PJTg63ARDZ8MT0Lth4SoNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  rstack@0.5.0:
-    resolution: {integrity: sha512-O+LHlNEfMf7C9EWWcAdt+KQiVyaR8nN0AjEaj4h4mv0G14BubZZ3lPuycFoZDwgGQd6Zstv7SIs/QHqfeba3Zg==}
+  rstack@0.5.1:
+    resolution: {integrity: sha512-6p5P+hvhLsGHHtAxx3qolsh/9U8wWB+R/d0zj76mTm1dptotg6tuLXuTn55SywNKvFJlEuxVYPXmLZnjoDEl3Q==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -1118,43 +1118,43 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rstackjs/cli-darwin-arm64@0.5.0':
+  '@rstackjs/cli-darwin-arm64@0.5.1':
     optional: true
 
-  '@rstackjs/cli-darwin-x64@0.5.0':
+  '@rstackjs/cli-darwin-x64@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-arm64-gnu@0.5.0':
+  '@rstackjs/cli-linux-arm64-gnu@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-arm64-musl@0.5.0':
+  '@rstackjs/cli-linux-arm64-musl@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-ppc64-gnu@0.5.0':
+  '@rstackjs/cli-linux-ppc64-gnu@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-riscv64-gnu@0.5.0':
+  '@rstackjs/cli-linux-riscv64-gnu@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-riscv64-musl@0.5.0':
+  '@rstackjs/cli-linux-riscv64-musl@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-s390x-gnu@0.5.0':
+  '@rstackjs/cli-linux-s390x-gnu@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-x64-gnu@0.5.0':
+  '@rstackjs/cli-linux-x64-gnu@0.5.1':
     optional: true
 
-  '@rstackjs/cli-linux-x64-musl@0.5.0':
+  '@rstackjs/cli-linux-x64-musl@0.5.1':
     optional: true
 
-  '@rstackjs/cli-win32-arm64-msvc@0.5.0':
+  '@rstackjs/cli-win32-arm64-msvc@0.5.1':
     optional: true
 
-  '@rstackjs/cli-win32-ia32-msvc@0.5.0':
+  '@rstackjs/cli-win32-ia32-msvc@0.5.1':
     optional: true
 
-  '@rstackjs/cli-win32-x64-msvc@0.5.0':
+  '@rstackjs/cli-win32-x64-msvc@0.5.1':
     optional: true
 
   '@rstest/core@0.11.6':
@@ -1470,7 +1470,7 @@ snapshots:
 
   rslog@2.2.0: {}
 
-  rstack@0.5.0(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2):
+  rstack@0.5.1(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2):
     dependencies:
       '@rsbuild/core': 2.1.10
       '@rslib/core': 1.0.0-beta.2(@microsoft/api-extractor@7.58.9(@types/node@24.13.3))(typescript@7.0.2)
@@ -1480,19 +1480,19 @@ snapshots:
       tinypool: 2.1.0
       yuku-parser: 0.8.4
     optionalDependencies:
-      '@rstackjs/cli-darwin-arm64': 0.5.0
-      '@rstackjs/cli-darwin-x64': 0.5.0
-      '@rstackjs/cli-linux-arm64-gnu': 0.5.0
-      '@rstackjs/cli-linux-arm64-musl': 0.5.0
-      '@rstackjs/cli-linux-ppc64-gnu': 0.5.0
-      '@rstackjs/cli-linux-riscv64-gnu': 0.5.0
-      '@rstackjs/cli-linux-riscv64-musl': 0.5.0
-      '@rstackjs/cli-linux-s390x-gnu': 0.5.0
-      '@rstackjs/cli-linux-x64-gnu': 0.5.0
-      '@rstackjs/cli-linux-x64-musl': 0.5.0
-      '@rstackjs/cli-win32-arm64-msvc': 0.5.0
-      '@rstackjs/cli-win32-ia32-msvc': 0.5.0
-      '@rstackjs/cli-win32-x64-msvc': 0.5.0
+      '@rstackjs/cli-darwin-arm64': 0.5.1
+      '@rstackjs/cli-darwin-x64': 0.5.1
+      '@rstackjs/cli-linux-arm64-gnu': 0.5.1
+      '@rstackjs/cli-linux-arm64-musl': 0.5.1
+      '@rstackjs/cli-linux-ppc64-gnu': 0.5.1
+      '@rstackjs/cli-linux-riscv64-gnu': 0.5.1
+      '@rstackjs/cli-linux-riscv64-musl': 0.5.1
+      '@rstackjs/cli-linux-s390x-gnu': 0.5.1
+      '@rstackjs/cli-linux-x64-gnu': 0.5.1
+      '@rstackjs/cli-linux-x64-musl': 0.5.1
+      '@rstackjs/cli-win32-arm64-msvc': 0.5.1
+      '@rstackjs/cli-win32-ia32-msvc': 0.5.1
+      '@rstackjs/cli-win32-x64-msvc': 0.5.1
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@module-federation/runtime-tools'

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "rstack-cli-best-practices": {
+      "source": "rstackjs/rstack-cli",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/rstack-cli-best-practices/SKILL.md",
+      "computedHash": "fa6e3305610cab62c9ec6be3f38a7dfc9917d1417bcd3dc449c46f1ccaec4a2a"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This upgrade keeps the repository aligned with the Rstack CLI 0.5.1 toolchain.
It updates `rstack` to 0.5.1, refreshes the lockfile, and uses the official `skills` package to sync the latest `rstack-cli-best-practices` Skill and its lock metadata.

## Related Links

- https://github.com/rstackjs/rstack-cli/releases/tag/v0.5.1