### PR TITLE
chore(deps): upgrade Rslint to v0.8.0

### DIFF
--- a/template-rslint/react-js/package.json
+++ b/template-rslint/react-js/package.json
@@ -6,6 +6,6 @@
     "lint": "rslint"
   },
   "devDependencies": {
-    "@rslint/core": "^0.6.5"
+    "@rslint/core": "^0.8.0"
   }
 }

--- a/template-rslint/react-ts/package.json
+++ b/template-rslint/react-ts/package.json
@@ -6,6 +6,6 @@
     "lint": "rslint"
   },
   "devDependencies": {
-    "@rslint/core": "^0.6.5"
+    "@rslint/core": "^0.8.0"
   }
 }

--- a/template-rslint/vanilla-js/package.json
+++ b/template-rslint/vanilla-js/package.json
@@ -6,6 +6,6 @@
     "lint": "rslint"
   },
   "devDependencies": {
-    "@rslint/core": "^0.6.5"
+    "@rslint/core": "^0.8.0"
   }
 }

--- a/template-rslint/vanilla-ts/package.json
+++ b/template-rslint/vanilla-ts/package.json
@@ -6,6 +6,6 @@
     "lint": "rslint"
   },
   "devDependencies": {
-    "@rslint/core": "^0.6.5"
+    "@rslint/core": "^0.8.0"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade `@rslint/core` to v0.8.0 and refresh the lockfile where applicable.
- Preserve the existing recommended-rule coverage under Rslint 0.8.
- Resolve newly surfaced lint diagnostics where needed.
- Verify the relevant lint checks pass.

## Related Links

- https://github.com/web-infra-dev/rslint/releases/tag/v0.8.0